### PR TITLE
Fix for the issue #40

### DIFF
--- a/src/next-rosetta.tsx
+++ b/src/next-rosetta.tsx
@@ -107,9 +107,9 @@ export type I18nProviderProps<T = any> = I18nProps<T> & {
  */
 export function I18nProvider<T = any>({ table, ...props }: I18nProviderProps<T>) {
   const i18nRef = useRef(rosetta());
-  const { locale, defaultLocale } = useRouter();
+  const { locale = "en", defaultLocale = ["en"] } = useRouter();
 
-  i18nRef.current.set(locale ?? defaultLocale!, table);
+  i18nRef.current.set(locale ?? defaultLocale, table);
   i18nRef.current.locale(locale);
 
   return <I18nContext.Provider value={i18nRef.current} {...props} />;


### PR DESCRIPTION
Please check: https://github.com/useflyyer/next-rosetta/issues/40

Here's a quick fix for it. For some reason, while using turborepo, the `useRouter` is not ready when `next-rosetta` is running. Therefore, this small fix will set default values to it.

Please pay attention to the removal of `!`. It became obsolete since, `defaultLocale` always has a default value.